### PR TITLE
docs: Add Node.JS Prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ It provides a function-calling interface for conversational AI systems, enabling
 
 In short: It gives your LLMs a voice and a phone number — turning chatbots into truly conversational agents.
 
+### 🧩 Prerequisites
+
+This project requires **Node.js** (which includes `npm` and `npx`).
+
+#### Installing Node.js
+
+* Visit the official Node.js website:
+  👉 [https://nodejs.org/en/download](https://nodejs.org/en/download)
+* Download and install the **LTS (Long-Term Support)** version for your platform (Windows, macOS, or Linux).
+
 ## Claude Desktop Setup
 
 1. Open `Claude Desktop` and press `CMD + ,` to go to `Settings`.


### PR DESCRIPTION
Adds a Prerequisites section to the README documenting that Node.js is required for the project.

 **Changes**

- Added a new "Prerequisites" section before the "Claude Desktop Setup" section
- Included instructions for installing Node.js with a link to the official download page
- Recommends installing the LTS (Long-Term Support) version

**Motivation**

Users attempting to use this MCP server need Node.js installed (for npm and npx commands), but this requirement wasn't explicitly documented in the README. This addition helps ensure users have the necessary prerequisites before attempting setup.