### PR TITLE
fix: correct phone numbers and contacts update endpoint URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 0.0.6
+
+### Patch Changes
+
+- fix: Correct phone numbers and contacts update endpoint URLs
+
 ## 0.0.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/src/sdk/justcall.ts
+++ b/src/sdk/justcall.ts
@@ -183,9 +183,9 @@ export class JustCallApiService extends BaseApiService {
   }
 
   updateContact(dto: UpdateContactDto): Promise<any> {
-    const { companyId, authToken, id, ...requestBody } = dto;
+    const { companyId, authToken, ...requestBody } = dto;
 
-    const url = `/v2.1/contacts/${id}`;
+    const url = `/v2.1/contacts`;
     const headers = this.getAuthHeaders(authToken as string);
 
     return this.executeApiCall(url, {
@@ -258,7 +258,7 @@ export class JustCallApiService extends BaseApiService {
         return acc;
       }, {} as Record<string, any>);
 
-    const url = `/v2.1/numbers`;
+    const url = `/v2.1/phone-numbers`;
     const headers = this.getAuthHeaders(authToken as string);
 
     return this.executeApiCall(url, { params, headers });
@@ -267,7 +267,7 @@ export class JustCallApiService extends BaseApiService {
   getNumber(dto: GetNumberDto): Promise<any> {
     const { companyId, authToken, id } = dto;
 
-    const url = `/v2.1/numbers/${id}`;
+    const url = `/v2.1/phone-numbers/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
     return this.executeApiCall(url, { headers });


### PR DESCRIPTION
## Summary
This PR fixes incorrect API endpoint URLs for phone numbers and contact update operations to align with the JustCall API specification.

## Changes
- **Contact Update**: Corrected endpoint from `/v2.1/contacts/${id}` to `/v2.1/contacts` and moved `id` to request body (src/sdk/justcall.ts:186-188)
- **Get Phone Numbers**: Fixed endpoint from `/v2.1/numbers` to `/v2.1/phone-numbers` (src/sdk/justcall.ts:261)
- **Get Phone Number**: Fixed endpoint from `/v2.1/numbers/${id}` to `/v2.1/phone-numbers/${id}` (src/sdk/justcall.ts:270)
- Version bumped to 0.0.6
- Updated CHANGELOG.md with fix description

## Impact
These endpoint corrections ensure that API calls work correctly with JustCall's API specification, fixing potential 404 or routing errors.