### PR TITLE
Add client identification headers to API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The default and recommended way to connect is via Streamable HTTP Transport:
 The JustCall MCP Server provides 29 tools organized into the following categories:
 
 ### 📞 Calls (5 tools)
+
 - **list_calls** - Lists all JustCall calls with various filtering options
 - **get_call** - Get a specific JustCall call by ID
 - **update_call** - Update a JustCall call (disposition, notes, rating)
@@ -74,10 +75,12 @@ The JustCall MCP Server provides 29 tools organized into the following categorie
 - **get_voice_agent_data** - Get voice agent data for a specific call
 
 ### 👥 Users & Agents (2 tools)
+
 - **list_users** - List all users/agents in the account
 - **get_user** - Get detailed information for a specific user/agent
 
 ### 💬 SMS & Messaging (8 tools)
+
 - **send_sms** - Send an SMS/text message to a contact
 - **list_sms** - Retrieve all SMS/text messages
 - **get_sms** - Get detailed information for a specific SMS/text message
@@ -88,24 +91,29 @@ The JustCall MCP Server provides 29 tools organized into the following categorie
 - **delete_sms_tag** - Delete a specific SMS tag
 
 ### 📇 Contacts (2 tools)
+
 - **list_contacts** - Retrieve all contacts from the CRM
 - **create_contact** - Create a new contact in the CRM
 
 ### 📊 Analytics (4 tools)
+
 - **get_agent_analytics** - Retrieve agent analytics data for specified date range
 - **get_account_analytics** - Retrieve account analytics data for specified date range
 - **get_number_analytics** - Retrieve number analytics data for specified date range
 - **get_sales_dialer_analytics** - Retrieve comprehensive analytics data for sales dialer campaigns
 
 ### 🔔 Webhooks (2 tools)
+
 - **list_webhooks** - Retrieve all configured webhooks
 - **create_webhook** - Create a new webhook endpoint to receive real-time notifications
 
 ### 📱 Phone Numbers (2 tools)
+
 - **list_numbers** - Retrieve all JustCall phone numbers
 - **get_number** - Retrieve detailed information for a specific JustCall phone number
 
 ### 📢 Sales Dialer Campaigns (4 tools)
+
 - **list_campaigns** - Retrieve all sales dialer campaigns
 - **get_campaign** - Retrieve detailed information for a specific sales dialer campaign
 - **create_campaign** - Create a new sales dialer campaign

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",
@@ -31,7 +31,7 @@
     "prepare": "npm run build",
     "build": "tsc && shx chmod +x dist/*.js",
     "start": "node dist/index.js",
-    "dev": "tsx watch src/index.ts",
+    "dev": "wrangler dev",
     "dev:stdio-example": "tsx examples/stdio-client.ts",
     "dev:sse-example": "tsx examples/sse-client.ts",
     "dev:shttp-example": "tsx examples/shttp-client.ts",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/saaslabsco/justcall-mcp-server",
     "source": "github"
   },
-  "version": "0.0.4",
+  "version": "0.0.7",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/sdk/justcall.ts
+++ b/src/sdk/justcall.ts
@@ -58,8 +58,8 @@ export class JustCallApiService extends BaseApiService {
   }
 
   // Calls Endpoints
-  listCalls(dto: ListCallsDto): Promise<any> {
-    const { authToken, ...queryParams } = dto;
+  listCalls(dto: ListCallsDto & { context?: any }): Promise<any> {
+    const { authToken, context, ...queryParams } = dto;
 
     // Build query parameters
     const params = Object.entries(queryParams)
@@ -76,11 +76,11 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/calls`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getCall(dto: GetCallDto): Promise<any> {
-    const { companyId, authToken, id, ...queryParams } = dto;
+  getCall(dto: GetCallDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, id, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -92,11 +92,11 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/calls/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  updateCall(dto: UpdateCallDto): Promise<any> {
-    const { companyId, authToken, id, ...requestBody } = dto;
+  updateCall(dto: UpdateCallDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, id, ...requestBody } = dto;
 
     const url = `/v2.1/calls/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -105,21 +105,22 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "PUT",
       data: requestBody,
+      context,
     });
   }
 
-  getCallJourney(dto: GetCallJourneyDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getCallJourney(dto: GetCallJourneyDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, id } = dto;
 
     const url = `/v2.1/calls/${id}/journey`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
   // Users/Agents Endpoints
-  listUsers(dto: ListUsersDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listUsers(dto: ListUsersDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -131,21 +132,21 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/users`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getUser(dto: GetUserDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getUser(dto: GetUserDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/users/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
   // Contacts Endpoints
-  listContacts(dto: ListContactsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listContacts(dto: ListContactsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -157,20 +158,20 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/contacts`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getContact(dto: GetContactDto): Promise<any> {
-    const { authToken, id } = dto;
+  getContact(dto: GetContactDto & { context?: any }): Promise<any> {
+    const { authToken, id, context } = dto;
 
     const url = `/v2.1/contacts/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
-  createContact(dto: CreateContactDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  createContact(dto: CreateContactDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/contacts`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -179,11 +180,12 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "POST",
       data: requestBody,
+      context,
     });
   }
 
-  updateContact(dto: UpdateContactDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  updateContact(dto: UpdateContactDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/contacts`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -192,12 +194,13 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "PUT",
       data: requestBody,
+      context,
     });
   }
 
   // SMS/Text Messages Endpoints
-  listSms(dto: ListSmsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listSms(dto: ListSmsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -209,11 +212,11 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/texts`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  sendSms(dto: SendSmsDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  sendSms(dto: SendSmsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/texts/new`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -222,20 +225,21 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "POST",
       data: requestBody,
+      context,
     });
   }
 
-  getSms(dto: GetSmsDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getSms(dto: GetSmsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/texts/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
-  checkSmsReply(dto: CheckSmsReplyDto): Promise<any> {
-    const { companyId, authToken, ...bodyParams } = dto;
+  checkSmsReply(dto: CheckSmsReplyDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...bodyParams } = dto;
 
     const url = `/v2.1/texts/checkreply`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -244,12 +248,13 @@ export class JustCallApiService extends BaseApiService {
       method: "POST",
       headers,
       data: bodyParams,
+      context,
     });
   }
 
   // Numbers Endpoints
-  listNumbers(dto: ListNumbersDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listNumbers(dto: ListNumbersDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -261,22 +266,22 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/phone-numbers`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getNumber(dto: GetNumberDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getNumber(dto: GetNumberDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/phone-numbers/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
   // Teams Endpoints
   // Webhook Endpoints
-  listWebhooks(dto: ListWebhooksDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listWebhooks(dto: ListWebhooksDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -288,11 +293,11 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/webhooks`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  createWebhook(dto: CreateWebhookDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  createWebhook(dto: CreateWebhookDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/webhooks`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -301,6 +306,7 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "POST",
       data: requestBody,
+      context,
     });
   }
 
@@ -310,8 +316,8 @@ export class JustCallApiService extends BaseApiService {
   // Call Queue Endpoints
 
   // SMS Tags Endpoints
-  listSmsTags(dto: ListSmsTagsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listSmsTags(dto: ListSmsTagsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -323,20 +329,20 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/texts/tags`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getSmsTag(dto: GetSmsTagDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getSmsTag(dto: GetSmsTagDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/texts/tags/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
-  createSmsTag(dto: CreateSmsTagDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  createSmsTag(dto: CreateSmsTagDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/texts/tags`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -345,11 +351,12 @@ export class JustCallApiService extends BaseApiService {
       headers,
       method: "POST",
       data: requestBody,
+      context,
     });
   }
 
-  deleteSmsTag(dto: DeleteSmsTagDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  deleteSmsTag(dto: DeleteSmsTagDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/texts/tags/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -357,6 +364,7 @@ export class JustCallApiService extends BaseApiService {
     return this.executeApiCall(url, {
       headers,
       method: "DELETE",
+      context,
     });
   }
 
@@ -377,8 +385,10 @@ export class JustCallApiService extends BaseApiService {
   // Call Tags Endpoints
 
   // Agent Analytics Endpoints
-  getAgentAnalytics(dto: GetAgentAnalyticsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  getAgentAnalytics(
+    dto: GetAgentAnalyticsDto & { context?: any }
+  ): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -393,6 +403,7 @@ export class JustCallApiService extends BaseApiService {
     return this.executeApiCall(url, {
       headers,
       params,
+      context,
     });
   }
 
@@ -401,8 +412,10 @@ export class JustCallApiService extends BaseApiService {
    * @param dto - GetAccountAnalyticsDto
    * @returns Promise<any>
    */
-  getAccountAnalytics(dto: GetAccountAnalyticsDto): Promise<any> {
-    const { authToken, ...queryParams } = dto;
+  getAccountAnalytics(
+    dto: GetAccountAnalyticsDto & { context?: any }
+  ): Promise<any> {
+    const { authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -414,11 +427,13 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/calls/analytics/account`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers, params });
+    return this.executeApiCall(url, { headers, params, context });
   }
 
-  getNumberAnalytics(dto: GetNumberAnalyticsDto): Promise<any> {
-    const { authToken, ...queryParams } = dto;
+  getNumberAnalytics(
+    dto: GetNumberAnalyticsDto & { context?: any }
+  ): Promise<any> {
+    const { authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -430,7 +445,7 @@ export class JustCallApiService extends BaseApiService {
     const url = `/v2.1/calls/analytics/number`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers, params });
+    return this.executeApiCall(url, { headers, params, context });
   }
 
   /**
@@ -438,12 +453,12 @@ export class JustCallApiService extends BaseApiService {
    * @param dto
    * @returns
    */
-  getVoiceAgentData(dto: GetVoiceAgentDto): Promise<any> {
-    const { authToken, id } = dto;
+  getVoiceAgentData(dto: GetVoiceAgentDto & { context?: any }): Promise<any> {
+    const { authToken, context, id } = dto;
 
     const url = `/v2.1/calls/${id}/voice-agent`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 }

--- a/src/sdk/salesdialer.ts
+++ b/src/sdk/salesdialer.ts
@@ -33,8 +33,10 @@ export class SalesDialerApiService extends BaseApiService {
   }
 
   // Sales Dialer Analytics Endpoint
-  getSalesDialerAnalytics(dto: GetSalesDialerAnalyticsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  getSalesDialerAnalytics(
+    dto: GetSalesDialerAnalyticsDto & { context?: any }
+  ): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -50,12 +52,12 @@ export class SalesDialerApiService extends BaseApiService {
     const url = `/v2.1/sales_dialer/analytics`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
   // Campaign Endpoints
-  listCampaigns(dto: ListCampaignsDto): Promise<any> {
-    const { companyId, authToken, ...queryParams } = dto;
+  listCampaigns(dto: ListCampaignsDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...queryParams } = dto;
 
     const params = Object.entries(queryParams)
       .filter(([_, value]) => value !== undefined && value !== null)
@@ -67,20 +69,20 @@ export class SalesDialerApiService extends BaseApiService {
     const url = `/v2.1/sales_dialer/campaigns`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { params, headers });
+    return this.executeApiCall(url, { params, headers, context });
   }
 
-  getCampaign(dto: GetCampaignDto): Promise<any> {
-    const { companyId, authToken, id } = dto;
+  getCampaign(dto: GetCampaignDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context } = dto;
 
     const url = `/v2.1/sales_dialer/campaigns/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
 
-    return this.executeApiCall(url, { headers });
+    return this.executeApiCall(url, { headers, context });
   }
 
-  createCampaign(dto: CreateCampaignDto): Promise<any> {
-    const { companyId, authToken, ...requestBody } = dto;
+  createCampaign(dto: CreateCampaignDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, context, ...requestBody } = dto;
 
     const url = `/v2.1/sales_dialer/campaigns`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -89,11 +91,12 @@ export class SalesDialerApiService extends BaseApiService {
       headers,
       method: "POST",
       data: requestBody,
+      context,
     });
   }
 
-  updateCampaign(dto: UpdateCampaignDto): Promise<any> {
-    const { companyId, authToken, id, ...requestBody } = dto;
+  updateCampaign(dto: UpdateCampaignDto & { context?: any }): Promise<any> {
+    const { companyId, authToken, id, context, ...requestBody } = dto;
 
     const url = `/v2.1/sales_dialer/campaigns/${id}`;
     const headers = this.getAuthHeaders(authToken as string);
@@ -102,6 +105,7 @@ export class SalesDialerApiService extends BaseApiService {
       headers,
       method: "PUT",
       data: requestBody,
+      context,
     });
   }
 }

--- a/src/tools/justcall/analytics.ts
+++ b/src/tools/justcall/analytics.ts
@@ -20,6 +20,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getAgentAnalytics({
         authToken,
+        context,
         ...params,
       });
     })
@@ -34,6 +35,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getAccountAnalytics({
         authToken,
+        context,
         ...params,
       });
     })
@@ -48,6 +50,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getNumberAnalytics({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/justcall/call.ts
+++ b/src/tools/justcall/call.ts
@@ -22,6 +22,7 @@ export const registerCallTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listCalls({
         authToken,
+        context, // Pass context for client identification
         ...params,
       });
     })
@@ -36,6 +37,7 @@ export const registerCallTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getCall({
         authToken,
+        context, // Pass context for client identification
         ...params,
       });
     })
@@ -50,6 +52,7 @@ export const registerCallTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.updateCall({
         authToken,
+        context, // Pass context for client identification
         ...params,
       });
     })
@@ -64,6 +67,7 @@ export const registerCallTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getCallJourney({
         authToken,
+        context, // Pass context for client identification
         ...params,
       });
     })
@@ -78,6 +82,7 @@ export const registerCallTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getVoiceAgentData({
         authToken,
+        context, // Pass context for client identification
         ...params,
       });
     })

--- a/src/tools/justcall/contacts.ts
+++ b/src/tools/justcall/contacts.ts
@@ -16,6 +16,7 @@ export const registerContactTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listContacts({
         authToken,
+        context,
         ...params,
       });
     })
@@ -30,6 +31,7 @@ export const registerContactTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createContact({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/justcall/numbers.ts
+++ b/src/tools/justcall/numbers.ts
@@ -16,6 +16,7 @@ export const registerNumberTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listNumbers({
         authToken,
+        context,
         ...params,
       });
     })
@@ -30,6 +31,7 @@ export const registerNumberTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getNumber({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/justcall/sms.ts
+++ b/src/tools/justcall/sms.ts
@@ -25,6 +25,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.sendSms({
         authToken,
+        context,
         ...params,
       });
     })
@@ -39,6 +40,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listSms({
         authToken,
+        context,
         ...params,
       });
     })
@@ -53,6 +55,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getSms({
         authToken,
+        context,
         ...params,
       });
     })
@@ -67,6 +70,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.checkSmsReply({
         authToken,
+        context,
         ...params,
       });
     })
@@ -81,6 +85,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listSmsTags({
         authToken,
+        context,
         ...params,
       });
     })
@@ -95,6 +100,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getSmsTag({
         authToken,
+        context,
         ...params,
       });
     })
@@ -109,6 +115,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createSmsTag({
         authToken,
+        context,
         ...params,
       });
     })
@@ -123,6 +130,7 @@ export const registerSmsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.deleteSmsTag({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/justcall/users.ts
+++ b/src/tools/justcall/users.ts
@@ -16,6 +16,7 @@ export const registerUserTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listUsers({
         authToken,
+        context,
         ...params,
       });
     })
@@ -30,6 +31,7 @@ export const registerUserTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getUser({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/justcall/webhooks.ts
+++ b/src/tools/justcall/webhooks.ts
@@ -16,6 +16,7 @@ export const registerWebhookTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listWebhooks({
         authToken,
+        context,
         ...params,
       });
     })
@@ -30,6 +31,7 @@ export const registerWebhookTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createWebhook({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/salesdialer/analytics.ts
+++ b/src/tools/salesdialer/analytics.ts
@@ -16,6 +16,7 @@ export const registerSalesDialerAnalyticsTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getSalesDialerAnalytics({
         authToken,
+        context,
         ...params,
       });
     })

--- a/src/tools/salesdialer/campaigns.ts
+++ b/src/tools/salesdialer/campaigns.ts
@@ -21,6 +21,7 @@ export const registerCampaignTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listCampaigns({
         authToken,
+        context,
         ...params,
       });
     })
@@ -35,6 +36,7 @@ export const registerCampaignTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getCampaign({
         authToken,
+        context,
         ...params,
       });
     })
@@ -49,6 +51,7 @@ export const registerCampaignTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.createCampaign({
         authToken,
+        context,
         ...params,
       });
     })
@@ -63,6 +66,7 @@ export const registerCampaignTools = (server: McpServer) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.updateCampaign({
         authToken,
+        context,
         ...params,
       });
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
This PR adds client identification capabilities to all JustCall MCP Server API requests by implementing a custom header system that tracks both the MCP server and the client application making requests.

## Changes
- **Client Identification System** (src/sdk/base-api.ts:1-36)
  - Added `buildUserAgent()` method that constructs a user-agent string combining server info (JustCall-MCP-Server/version) with client details from the MCP protocol context
  - Implemented automatic `x-justcall-client` header injection in all API requests
  - Falls back gracefully when client information is unavailable

- **API Service Updates**
  - Updated all 29+ API methods in `JustCallApiService` (src/sdk/justcall.ts) to accept and pass through MCP context
  - Updated all API methods in `SalesDialerApiService` (src/sdk/salesdialer.ts) to accept and pass through MCP context
  - Modified method signatures to support optional `context` parameter without breaking changes

- **Tool Handler Updates**
  - Updated all tool implementations across:
    - Call tools (src/tools/justcall/call.ts)
    - SMS tools (src/tools/justcall/sms.ts)
    - User tools (src/tools/justcall/users.ts)
    - Contact tools (src/tools/justcall/contacts.ts)
    - Analytics tools (src/tools/justcall/analytics.ts)
    - Number tools (src/tools/justcall/numbers.ts)
    - Webhook tools (src/tools/justcall/webhooks.ts)
    - Sales Dialer tools (src/tools/salesdialer/*)
  - All tool handlers now pass the MCP context to underlying API services

- **Package & Configuration**
  - Version bump: 0.0.6 → 0.0.7 (package.json, server.json)
  - Updated dev script to use `wrangler dev` for better development workflow
  - Minor TypeScript configuration adjustments

- **Documentation**
  - Improved README.md formatting with better section spacing

## Benefits
- **Better Analytics**: JustCall can now track which clients (Claude Desktop, custom implementations, etc.) are using the MCP server
- **Debugging**: Easier to identify and debug issues based on client type
- **Future Features**: Enables client-specific feature flags or behavior customization
- **Transparency**: Server version is now included in all requests for better version tracking

## Technical Details
The header format is: `JustCall-MCP-Server/{version} (Client: {clientName}/{clientVersion})`

Example: `JustCall-MCP-Server/0.0.7 (Client: Claude Desktop/1.2.0)`