### PR TITLE
fix: Updated Base API to support client info details when available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated Base API to support client info details when available.
+
 ## 0.0.6
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/saaslabsco/justcall-mcp-server",
     "source": "github"
   },
-  "version": "0.0.8",
+  "version": "0.0.9",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/sdk/base-api.ts
+++ b/src/sdk/base-api.ts
@@ -15,6 +15,34 @@ export abstract class BaseApiService {
    * @returns The user-agent string
    */
   protected buildUserAgent(context?: any): string {
+     // Try to get client info from MCP context
+     const clientInfo = context?.meta?.clientInfo || context?.clientInfo;
+    
+     if (clientInfo) {
+       const clientName = clientInfo.name || 'Unknown';
+       const clientVersion = clientInfo.version || '';
+       
+       // Build platform info (e.g., "darwin arm64")
+       let platformInfo = '';
+       if (clientInfo.platform) {
+         const platform = clientInfo.platform.os || '';
+         const arch = clientInfo.platform.arch || '';
+         platformInfo = [platform, arch].filter(Boolean).join(' ');
+       }
+       
+       // Format: JustCall-MCP-Server/0.0.7 (Client: Cursor/1.7.46 (darwin arm64))
+       let clientStr = clientName;
+       if (clientVersion) {
+         clientStr += `/${clientVersion}`;
+       }
+       if (platformInfo) {
+         clientStr += ` (${platformInfo})`;
+       }
+       
+       return `${this.SERVER_NAME}/${version} (Client: ${clientStr})`;
+     }
+     
+     // Fallback to user-agent header if clientInfo not available
     const userAgent = context?.requestInfo?.headers?.["user-agent"];
     if (userAgent) {
       return `${this.SERVER_NAME}/${version} (Client: ${userAgent})`;


### PR DESCRIPTION
### Summary
Enhanced the User-Agent string generation to include client information from the MCP (Model Context Protocol) context, providing better visibility into which clients are making API requests to JustCall.

### Changes Made

**Modified: `src/sdk/base-api.ts`**

Added logic to extract and format client information from the MCP context:

1. **Client Info Extraction**: Attempts to retrieve client info from `context?.meta?.clientInfo` or `context?.clientInfo`

2. **Enhanced User-Agent Format**: Constructs a comprehensive User-Agent string in the format:
   ```
   JustCall-MCP-Server/{version} (Client: {ClientName}/{ClientVersion} ({platform} {arch}))
   ```
   Example: `JustCall-MCP-Server/0.0.7 (Client: Cursor/1.7.46 (darwin arm64))`

3. **Platform Information**: Includes OS and architecture details when available from `clientInfo.platform`

4. **Graceful Fallback**: Maintains backward compatibility by falling back to the user-agent header if clientInfo is not available in the context

### Benefits

- **Better Observability**: API requests now include detailed client information for debugging and analytics
- **Context Awareness**: Leverages MCP protocol's client info capabilities
- **Backward Compatible**: Existing functionality is preserved with fallback mechanism
- **Rich Metadata**: Captures client name, version, and platform information in a standardized format