### PR TITLE
feat: support API authentication via URL query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 0.0.10
+
+### Patch Changes
+
+- Support url params for api secret
+
 ## 0.0.9
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/saaslabsco/justcall-mcp-server",
     "source": "github"
   },
-  "version": "0.0.9",
+  "version": "0.0.10",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,23 @@ export class JustCallMCP extends McpAgent {
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const url = new URL(request.url);
+    if (
+      !request.headers.get("Authorization") &&
+      url.searchParams.get("key") &&
+      url.searchParams.get("secret")
+    ) {
+      // Extract auth credentials from query parameters
+      const key = url.searchParams.get("key");
+      const secret = url.searchParams.get("secret");
 
+      // If credentials are in the URL, add them to request headers
+      // This ensures per-request isolation (no global state)
+      if (key && secret) {
+        const headers = new Headers(request.headers);
+        headers.set("Authorization", `${key}:${secret}`);
+        request = new Request(request, { headers });
+      }
+    }
     if (url.pathname === "/sse" || url.pathname === "/sse/message") {
       return JustCallMCP.serveSSE("/sse").fetch(request, env, ctx);
     }

--- a/src/sdk/base-api.ts
+++ b/src/sdk/base-api.ts
@@ -15,34 +15,34 @@ export abstract class BaseApiService {
    * @returns The user-agent string
    */
   protected buildUserAgent(context?: any): string {
-     // Try to get client info from MCP context
-     const clientInfo = context?.meta?.clientInfo || context?.clientInfo;
-    
-     if (clientInfo) {
-       const clientName = clientInfo.name || 'Unknown';
-       const clientVersion = clientInfo.version || '';
-       
-       // Build platform info (e.g., "darwin arm64")
-       let platformInfo = '';
-       if (clientInfo.platform) {
-         const platform = clientInfo.platform.os || '';
-         const arch = clientInfo.platform.arch || '';
-         platformInfo = [platform, arch].filter(Boolean).join(' ');
-       }
-       
-       // Format: JustCall-MCP-Server/0.0.7 (Client: Cursor/1.7.46 (darwin arm64))
-       let clientStr = clientName;
-       if (clientVersion) {
-         clientStr += `/${clientVersion}`;
-       }
-       if (platformInfo) {
-         clientStr += ` (${platformInfo})`;
-       }
-       
-       return `${this.SERVER_NAME}/${version} (Client: ${clientStr})`;
-     }
-     
-     // Fallback to user-agent header if clientInfo not available
+    // Try to get client info from MCP context
+    const clientInfo = context?.meta?.clientInfo || context?.clientInfo;
+
+    if (clientInfo) {
+      const clientName = clientInfo.name || "Unknown";
+      const clientVersion = clientInfo.version || "";
+
+      // Build platform info (e.g., "darwin arm64")
+      let platformInfo = "";
+      if (clientInfo.platform) {
+        const platform = clientInfo.platform.os || "";
+        const arch = clientInfo.platform.arch || "";
+        platformInfo = [platform, arch].filter(Boolean).join(" ");
+      }
+
+      // Format: JustCall-MCP-Server/0.0.7 (Client: Cursor/1.7.46 (darwin arm64))
+      let clientStr = clientName;
+      if (clientVersion) {
+        clientStr += `/${clientVersion}`;
+      }
+      if (platformInfo) {
+        clientStr += ` (${platformInfo})`;
+      }
+
+      return `${this.SERVER_NAME}/${version} (Client: ${clientStr})`;
+    }
+
+    // Fallback to user-agent header if clientInfo not available
     const userAgent = context?.requestInfo?.headers?.["user-agent"];
     if (userAgent) {
       return `${this.SERVER_NAME}/${version} (Client: ${userAgent})`;


### PR DESCRIPTION
Add support for passing authentication credentials through 'key' and 'secret' URL query parameters as an alternative to the Authorization header. This provides flexibility for environments where setting custom headers is challenging (e.g., browser testing, simple integrations).

When both parameters are present and no Authorization header exists, the credentials are automatically converted to the Authorization header format (key:secret) per request, ensuring stateless operation without global state modifications.

Changes:
- Add query parameter extraction logic in fetch handler (src/index.ts:33-45)
- Bump version to 0.0.10
- Update CHANGELOG.md