### PR TITLE
feat: Add OAuth2 authentication support for enhanced security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @justcall/mcp-server
 
+## 1.0.0
+
+### Patch Changes
+
+- Add OAuth2 authentication support for enhanced security
+  - Implement OAuth2 authorization server metadata endpoint (`/.well-known/oauth-authorization-server`)
+  - Add OAuth2 configuration (S256 code challenge method)
+  - Protect MCP and SSE endpoints with Bearer token authentication
+  - Add token validation middleware for `/mcp`, `/sse`, and `/sse/message` endpoints
+  - Support authorization code grant flow with client secret authentication
+  - Add utility function to extract auth tokens from request context
+
 ## 0.0.11
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -60,7 +60,44 @@ The default and recommended way to connect is via Streamable HTTP Transport:
 
 - Connect to `https://mcp.justcall.host/mcp` from any MCP client using Streamable HTTP Transport
 - Include your JustCall API key as a bearer token in the request headers
-- Example header: `Authorization: <JUSTCALL_API_KEY>:<JUSTCALL_API_SECRET>`
+- Example header: `Authorization: Bearer <JUSTCALL_API_KEY>:<JUSTCALL_API_SECRET>`
+
+## Authentication & Security
+
+The JustCall MCP Server implements OAuth2 authentication for secure access to all endpoints.
+
+### OAuth2 Configuration
+
+The server supports OAuth2 authorization with the following features:
+
+- **Authorization Endpoint**: OAuth2 authorization server metadata is available at `/.well-known/oauth-authorization-server`
+- **Grant Type**: Authorization code flow with PKCE (Proof Key for Code Exchange)
+- **Code Challenge Method**: S256 (SHA-256)
+- **Token Authentication**: All MCP and SSE endpoints require Bearer token authentication
+
+### Protected Endpoints
+
+The following endpoints require valid Bearer token authentication:
+
+- `/mcp` - Main MCP endpoint
+- `/sse` - Server-Sent Events endpoint
+- `/sse/message` - SSE message endpoint
+
+### Authentication Header Format
+
+Include your JustCall API credentials as a Bearer token:
+
+```
+Authorization: Bearer <JWT_TOKEN_BY_OAUTH>
+Authorization: Bearer <JUSTCALL_API_KEY>:<JUSTCALL_API_SECRET>
+```
+
+### Public Endpoints
+
+The following endpoints are publicly accessible:
+
+- `/health` - Health check endpoint (returns 200 OK)
+- `/.well-known/oauth-authorization-server` - OAuth2 authorization server metadata
 
 ## Available Tools
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "0.0.11",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/saaslabsco/justcall-mcp-server",
     "source": "github"
   },
-  "version": "0.0.11",
+  "version": "1.0.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/constants/oauth.ts
+++ b/src/constants/oauth.ts
@@ -1,0 +1,15 @@
+const devApiOauth2Url = "https://api.justcall.io/v2.1/oauth";
+const mcpOauth2Url = "https://app.justcall.io/apex";
+
+export const OAUTH2_CONFIG = {
+  issuer: devApiOauth2Url,
+  authorization_endpoint: `${mcpOauth2Url}/mcp`,
+  registration_endpoint: `${devApiOauth2Url}/register`,
+  token_endpoint: `${devApiOauth2Url}/token`,
+  response_types_supported: ["code"],
+  grant_types_supported: ["authorization_code"],
+  token_endpoint_auth_methods_supported: ["client_secret_post"],
+  scopes_supported: ["openid"],
+  response_modes_supported: ["query"],
+  code_challenge_methods_supported: ["S256"],
+};

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -45,11 +45,9 @@ export function createToolHandler<T>(
  */
 export function getAuthToken(context?: any): string {
   const authHeader = context?.requestInfo?.headers.authorization;
-  const [apiKey, apiSecret] =
-    authHeader?.replace("Bearer ", "").split(":") || [];
+  const apiKey = authHeader?.replace("Bearer ", "");
   const authToken =
-    apiKey && apiSecret
-      ? `${apiKey}:${apiSecret}`
-      : `${process.env.JUSTCALL_API_KEY}:${process.env.JUSTCALL_API_SECRET}`;
+    apiKey ??
+    `${process.env.JUSTCALL_API_KEY}:${process.env.JUSTCALL_API_SECRET}`;
   return authToken;
 }


### PR DESCRIPTION
## Overview
This PR implements OAuth2 authentication for the JustCall MCP Server to enhance security and provide standardized authentication flows.

## Changes
### Security Enhancements
- ✅ Implemented OAuth2 authorization server metadata endpoint (`/.well-known/oauth-authorization-server`)
- ✅ Added OAuth2 configuration with S256 code challenge method (PKCE support)
- ✅ Protected MCP and SSE endpoints with Bearer token authentication
- ✅ Added token validation middleware for `/mcp`, `/sse`, and `/sse/message` endpoints
- ✅ Support authorization code grant flow with client secret authentication

### New Features
- Added `/health` endpoint for health checks
- Added `/.well-known/oauth-authorization-server` public endpoint for OAuth2 discovery

### Code Improvements
- Created OAuth2 constants configuration (`src/constants/oauth.ts`)
- Refactored `getAuthToken` utility function to support both JWT tokens and API key:secret format
- Added `checkOAuthToken` middleware function for request validation

### Documentation
- Updated README with comprehensive OAuth2 authentication guide
- Added details about protected endpoints and authentication header format
- Updated CHANGELOG with detailed list of changes

### Version Bump
- Updated version from `0.0.11` to `1.0.0` (breaking change - authentication now required)

## Testing
- [ ] Verify OAuth2 metadata endpoint returns correct configuration
- [ ] Test Bearer token authentication on protected endpoints
- [ ] Verify backward compatibility with existing API key:secret format
- [ ] Test health check endpoint accessibility
- [ ] Confirm unauthorized access returns 401 status

## Breaking Changes
⚠️ **This is a breaking change** - All MCP and SSE endpoints now require Bearer token authentication. Clients must include `Authorization: Bearer <token>` header.

## Co-Authors
- @akashyadav (Akash Yadav)
- @mayankbanga (Mayank Banga)