### PR TITLE
Add readonly hints to MCP tools for better discoverability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,6 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Please complete the following information about the MCP client or AI agent:**
+
 - AI agent [eg. Claude, Chat GPT, Cursor, etc.]
 - Model [eg. Claude Sonnet 4.5, GPT 5.1, etc.]
 - Client type [eg. Web, Desktop, Extension, etc.]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement
-assignees: ''
-
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @justcall/mcp-server
 
+## 1.1.0
+
+### Minor Changes
+
+- Add readOnlyHint metadata to all read-only tools across the JustCall and
+  Sales Dialer tool sets. This enhancement helps MCP clients identify which
+  tools perform read-only operations, enabling better tool selection and
+  usage patterns.
+
+  The readOnlyHint is set to true for all tools that only retrieve data
+  without modifying state, including:
+
+  - Call retrieval tools (list_calls, get_call, get_call_journey, etc.)
+  - Contact listing and retrieval tools
+  - Analytics tools
+  - SMS/WhatsApp message retrieval tools
+  - User and user group listing tools
+  - Webhook listing tools
+  - Number listing tools
+  - Appointment slot listing tools
+  - AI analysis retrieval tools
+  - Voice agent listing tools
+  - Sales Dialer read-only operations
+
+  This change improves tool discoverability and helps AI agents make more
+  informed decisions about which tools to use for different operations.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://justcall.io",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "icons": [
     {
       "mimeType": "image/png",

--- a/src/tools/justcall/ai.ts
+++ b/src/tools/justcall/ai.ts
@@ -17,6 +17,9 @@ export const registerAiTools = (server: McpServer) => {
     "list_calls_ai_analysis",
     "Retrieve AI-generated analysis for all calls associated with either JustCall or Sales Dialer",
     ListCallsAiDataSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listCallsAiData({
@@ -31,6 +34,9 @@ export const registerAiTools = (server: McpServer) => {
     "get_call_ai_analysis",
     "Retrieve AI-generated analysis for a specific call by Call ID associated with either JustCall or Sales Dialer",
     GetCallAiDataSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getCallAiData({
@@ -45,6 +51,9 @@ export const registerAiTools = (server: McpServer) => {
     "list_meetings_ai_analysis",
     "Retrieve AI-generated analysis for recorded meetings",
     ListMeetingsAiDataSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listMeetingsAiData({
@@ -59,6 +68,9 @@ export const registerAiTools = (server: McpServer) => {
     "get_meeting_ai_analysis",
     "Retrieve AI-generated analysis for a specific meeting identified by Instance ID",
     GetMeetingAiDataSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getMeetingAiData({

--- a/src/tools/justcall/analytics.ts
+++ b/src/tools/justcall/analytics.ts
@@ -16,6 +16,9 @@ export const registerAnalyticsTools = (server: McpServer) => {
     "get_agent_analytics",
     "Retrieve call performance analytics for a specific agent identified by Agent ID",
     GetAgentAnalyticsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getAgentAnalytics({
@@ -31,6 +34,9 @@ export const registerAnalyticsTools = (server: McpServer) => {
     "get_account_analytics",
     "Retrieve aggregated call analytics at the JustCall account level",
     GetAccountAnalyticsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getAccountAnalytics({
@@ -46,6 +52,9 @@ export const registerAnalyticsTools = (server: McpServer) => {
     "get_number_analytics",
     "Retrieve call analytics for a specific JustCall phone number",
     GetNumberAnalyticsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getNumberAnalytics({

--- a/src/tools/justcall/appointments.ts
+++ b/src/tools/justcall/appointments.ts
@@ -16,6 +16,9 @@ export const registerAppointmentTools = (server: McpServer) => {
     "list_appointment_slots",
     "Retrieve all available time slots for appointments on a specific JustCall calendar",
     ListAppointmentSlotsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listAppointmentSlots({
@@ -44,6 +47,9 @@ export const registerAppointmentTools = (server: McpServer) => {
     "get_appointment",
     "Retrieve details of a specific appointment by its ID",
     GetAppointmentSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getAppointment({

--- a/src/tools/justcall/call.ts
+++ b/src/tools/justcall/call.ts
@@ -13,11 +13,14 @@ import {
 export const registerCallTools = (server: McpServer) => {
   const justcallAPIservice = new JustCallApiService();
 
-  // List Calls Tool
+  // Get Call Tool
   server.tool(
     "list_calls",
     "Retrieve all calls associated with the JustCall account",
     ListCallsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listCalls({
@@ -33,6 +36,9 @@ export const registerCallTools = (server: McpServer) => {
     "get_call",
     "Retrieve detailed information for a specific call by Call ID",
     GetCallSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getCall({
@@ -63,6 +69,9 @@ export const registerCallTools = (server: McpServer) => {
     "get_call_journey",
     "Fetch the sequence of events for a specific call identified by Call ID",
     GetCallJourneySchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getCallJourney({
@@ -78,6 +87,9 @@ export const registerCallTools = (server: McpServer) => {
     "get_voice_agent_call",
     "Retrieve voice agent related data for a specific call identified by Call ID",
     GetVoiceAgentSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getVoiceAgentData({

--- a/src/tools/justcall/contacts.ts
+++ b/src/tools/justcall/contacts.ts
@@ -19,6 +19,9 @@ export const registerContactTools = (server: McpServer) => {
     "list_contacts",
     "Retrieve all contacts associated with the JustCall account",
     ListContactsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listContacts({
@@ -34,6 +37,9 @@ export const registerContactTools = (server: McpServer) => {
     "get_contact",
     "Retrieve detailed information for a specific contact by ID",
     GetContactSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getContact({

--- a/src/tools/justcall/numbers.ts
+++ b/src/tools/justcall/numbers.ts
@@ -12,6 +12,9 @@ export const registerNumberTools = (server: McpServer) => {
     "list_numbers",
     "Retrieve all phone numbers associated with the JustCall account",
     ListNumbersSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listNumbers({
@@ -27,6 +30,9 @@ export const registerNumberTools = (server: McpServer) => {
     "get_number",
     "Retrieve detailed information for a specific phone number by ID",
     GetNumberSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getNumber({

--- a/src/tools/justcall/sms.ts
+++ b/src/tools/justcall/sms.ts
@@ -39,6 +39,9 @@ export const registerSmsTools = (server: McpServer) => {
     "list_sms",
     "Retrieve all sms/text messages associated with the JustCall account",
     ListSmsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listSms({
@@ -54,6 +57,9 @@ export const registerSmsTools = (server: McpServer) => {
     "get_sms",
     "Retrieve detailed information for a specific sms/text by ID",
     GetSmsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getSms({
@@ -69,6 +75,9 @@ export const registerSmsTools = (server: McpServer) => {
     "check_sms_reply",
     "Check for the most recent inbound sms/text message from a contact number",
     CheckSmsReplySchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.checkSmsReply({
@@ -84,6 +93,9 @@ export const registerSmsTools = (server: McpServer) => {
     "list_sms_tags",
     "Retrieve the list of all sms tags defined in the JustCall account",
     ListSmsTagsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listSmsTags({
@@ -99,6 +111,9 @@ export const registerSmsTools = (server: McpServer) => {
     "get_sms_tag",
     "Retrieve details of a specific sms tag by ID",
     GetSmsTagSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getSmsTag({
@@ -144,6 +159,9 @@ export const registerSmsTools = (server: McpServer) => {
     "list_sms_threads",
     "Retrieve all sms threads/conversations associated with a JustCall number",
     ListSmsThreadsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listSmsThreads({
@@ -158,6 +176,9 @@ export const registerSmsTools = (server: McpServer) => {
     "get_sms_thread",
     "Retrieve a specific sms thread/conversation by ID",
     GetSmsThreadSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getSmsThread({

--- a/src/tools/justcall/userGroups.ts
+++ b/src/tools/justcall/userGroups.ts
@@ -15,6 +15,9 @@ export const registerUserGroupTools = (server: McpServer) => {
     "list_user_groups",
     "Retrieve all user groups defined in the JustCall account",
     ListUserGroupsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listUserGroups({
@@ -29,6 +32,9 @@ export const registerUserGroupTools = (server: McpServer) => {
     "get_user_group",
     "Retrieve detailed information for a specific user group by ID",
     GetUserGroupSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getUserGroup({

--- a/src/tools/justcall/users.ts
+++ b/src/tools/justcall/users.ts
@@ -16,6 +16,9 @@ export const registerUserTools = (server: McpServer) => {
     "list_users",
     "Retrieve all users associated with the JustCall account",
     ListUsersSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listUsers({
@@ -31,6 +34,9 @@ export const registerUserTools = (server: McpServer) => {
     "get_user",
     "Retrieve detailed information for a specific user by ID",
     GetUserSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getUser({

--- a/src/tools/justcall/voiceAgent.ts
+++ b/src/tools/justcall/voiceAgent.ts
@@ -15,6 +15,9 @@ export const registerVoiceAgentTools = (server: McpServer) => {
     "list_voice_agents",
     "Retrieve all AI voice agents associated with the JustCall account",
     ListVoiceAgentsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listVoiceAgents({

--- a/src/tools/justcall/webhooks.ts
+++ b/src/tools/justcall/webhooks.ts
@@ -12,6 +12,9 @@ export const registerWebhookTools = (server: McpServer) => {
     "list_webhooks",
     "Retrieve all configured webhooks",
     ListWebhooksSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listWebhooks({

--- a/src/tools/justcall/whatsapp.ts
+++ b/src/tools/justcall/whatsapp.ts
@@ -18,6 +18,9 @@ export const registerWhatsAppTools = (server: McpServer) => {
     "list_whatsapp_messages",
     "Retrieve all whatsapp messages associated with the JustCall account",
     ListWhatsAppMessagesSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listWhatsAppMessages({
@@ -32,6 +35,9 @@ export const registerWhatsAppTools = (server: McpServer) => {
     "get_whatsapp_message",
     "Retrieve detailed information for a specific whatsapp message by ID",
     GetWhatsAppMessageSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.getWhatsAppMessage({
@@ -60,6 +66,9 @@ export const registerWhatsAppTools = (server: McpServer) => {
     "list_whatsapp_templates",
     "Retrieve all whatsapp message templates available in the JustCall account",
     ListWhatsAppTemplatesSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.listWhatsAppTemplates({
@@ -74,6 +83,9 @@ export const registerWhatsAppTools = (server: McpServer) => {
     "check_whatsapp_message_reply",
     "Check for the most recent inbound whatsapp message from a contact number",
     CheckWhatsAppReplySchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.checkWhatsAppReply({

--- a/src/tools/salesdialer/analytics.ts
+++ b/src/tools/salesdialer/analytics.ts
@@ -12,6 +12,9 @@ export const registerSalesDialerAnalyticsTools = (server: McpServer) => {
     "get_salesdialer_agent_analytics",
     "Retrieve call performance analytics of a specific agent for a Sales Dialer campaign",
     GetSalesDialerAnalyticsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getSalesDialerAnalytics({

--- a/src/tools/salesdialer/calls.ts
+++ b/src/tools/salesdialer/calls.ts
@@ -15,6 +15,9 @@ export const registerSalesDialerCallTools = (server: McpServer) => {
     "list_salesdialer_calls",
     "Retrieve all calls made via the Sales Dialer in JustCall",
     ListSalesDialerCallsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listSalesDialerCalls({
@@ -29,6 +32,9 @@ export const registerSalesDialerCallTools = (server: McpServer) => {
     "get_salesdialer_call",
     "Retrieve detailed information for a specific Sales Dialer call by Call ID",
     GetSalesDialerCallSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getSalesDialerCall({

--- a/src/tools/salesdialer/campaigns.ts
+++ b/src/tools/salesdialer/campaigns.ts
@@ -19,6 +19,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "list_salesdialer_campaigns",
     "Retrieve all Sales Dialer campaigns in the JustCall account",
     ListCampaignsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listCampaigns({
@@ -34,6 +37,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "get_salesdialer_campaign",
     "Retrieve detailed information for a specific Sales Dialer campaign by ID",
     GetCampaignSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getCampaign({
@@ -79,6 +85,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "list_salesdialer_campaign_contacts",
     "Retrieve all contacts in a specific Sales Dialer campaign identified by Campaign ID",
     ListCampaignContactsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listCampaignContacts({

--- a/src/tools/salesdialer/contacts.ts
+++ b/src/tools/salesdialer/contacts.ts
@@ -21,6 +21,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "list_salesdialer_contacts",
     "Retrieve all contacts from Sales Dialer in the JustCall account",
     ListSalesDialerContactsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listSalesDialerContacts({
@@ -35,6 +38,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "get_salesdialer_contact",
     "Retrieve detailed information for a specific contact in Sales Dialer by ID",
     GetSalesDialerContactSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.getSalesDialerContact({
@@ -91,6 +97,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "import_salesdialer_contacts_status",
     "Check the status of a bulk import job/request by its batch ID",
     ImportSalesDialerContactsStatusSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.importSalesDialerContactsStatus({
@@ -119,6 +128,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "list_salesdialer_custom_fields",
     "Fetch all custom contact fields defined in your Sales Dialer account and their details",
     ListSalesDialerCustomFieldsSchema,
+    {
+      readOnlyHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.listSalesDialerCustomFields({


### PR DESCRIPTION
### Summary

This PR adds `readOnlyHint` metadata annotations to all read-only tools in the JustCall MCP Server. This enhancement improves tool discoverability and helps MCP clients (including AI agents) better understand which tools are safe to use for read-only operations.

### Changes

#### Core Changes

- **Added `readOnlyHint: true` to read-only tools**: All tools that only retrieve data without modifying state now include the `readOnlyHint: true` metadata option
- **Updated 16 tool files**: Applied readonly annotations across JustCall and Sales Dialer tool sets

#### Files Modified

- **Tool files** (16 files):

  - `src/tools/justcall/ai.ts`
  - `src/tools/justcall/analytics.ts`
  - `src/tools/justcall/appointments.ts`
  - `src/tools/justcall/call.ts`
  - `src/tools/justcall/contacts.ts`
  - `src/tools/justcall/numbers.ts`
  - `src/tools/justcall/sms.ts`
  - `src/tools/justcall/userGroups.ts`
  - `src/tools/justcall/users.ts`
  - `src/tools/justcall/voiceAgent.ts`
  - `src/tools/justcall/webhooks.ts`
  - `src/tools/justcall/whatsapp.ts`
  - `src/tools/salesdialer/analytics.ts`
  - `src/tools/salesdialer/calls.ts`
  - `src/tools/salesdialer/campaigns.ts`
  - `src/tools/salesdialer/contacts.ts`

- **Documentation files** (2 files):
  - `.github/ISSUE_TEMPLATE/bug_report.md` - Minor formatting improvements
  - `.github/ISSUE_TEMPLATE/feature_request.md` - Minor formatting improvements

### Tool Categories with ReadOnly Annotations

#### JustCall Tools

- **Calls**: `list_calls`, `get_call`, `get_call_journey`, `get_voice_agent_call`
- **Users**: `list_users`, `get_user`
- **SMS**: `list_sms`, `get_sms`, `check_sms_reply`, `list_sms_tags`, `get_sms_tag`, `list_sms_threads`, `get_sms_thread`
- **Contacts**: `list_contacts`, `get_contact`
- **Analytics**: `get_agent_analytics`, `get_account_analytics`, `get_number_analytics`
- **Webhooks**: `list_webhooks`
- **Numbers**: `list_numbers`, `get_number`
- **User Groups**: `list_user_groups`, `get_user_group`
- **Appointments**: `list_appointment_slots`, `get_appointment`
- **WhatsApp**: `list_whatsapp_messages`, `get_whatsapp_message`, `check_whatsapp_message_reply`, `list_whatsapp_templates`
- **AI Analysis**: `list_calls_ai_analysis`, `get_call_ai_analysis`, `list_meetings_ai_analysis`, `get_meeting_ai_analysis`
- **Voice Agents**: `list_voice_agents`

#### Sales Dialer Tools

- **Campaigns**: `list_campaigns`, `get_campaign`
- **Contacts**: `list_salesdialer_contacts`, `get_salesdialer_contact`, `list_salesdialer_custom_fields`
- **Calls**: `list_salesdialer_calls`, `get_salesdialer_call`
- **Analytics**: `get_sales_dialer_analytics`, `get_salesdialer_agent_analytics`

### Benefits

1. **Improved Tool Discoverability**: MCP clients can now programmatically identify read-only tools
2. **Better AI Agent Decision Making**: AI agents can make more informed choices about which tools to use
3. **Enhanced Safety**: Clear distinction between read and write operations helps prevent accidental modifications
4. **Future-Proof**: Sets foundation for additional tool metadata and categorization

### Testing

- [x] Verified all read-only tools include `readOnlyHint: true`
- [x] Confirmed write operations (create, update, delete) do not have readonly annotations
- [x] Tested tool registration and functionality remains unchanged
- [x] Verified type definitions compile correctly

### Backward Compatibility

✅ **Fully backward compatible** - This change only adds optional metadata and does not modify any existing tool behavior or API contracts.

### Related Issues

<!-- Link to related issues if any -->

- Closes #24

**Note**: This PR focuses on adding metadata annotations without changing tool functionality. All existing tool behavior remains unchanged.