### PR TITLE
Fix CSP error for JustCall domains in OpenAI Apps SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 1.2.1
+
+### Patch Changes
+
+- 14dd998: Fix CSP error for JustCall domains in Open AI Apps SDK
+
 ## 1.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
     "source": "github"
   },
   "websiteUrl": "https://justcall.io",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "icons": [
     {
       "mimeType": "image/png",

--- a/src/tools/justcall/call.ts
+++ b/src/tools/justcall/call.ts
@@ -58,6 +58,13 @@ export const registerCallTools = (server: McpServer) => {
       text: "Calls list",
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-list.html",
+        "openai/widgetCSP": {
+          connect_domains: ["https://app.justcall.io"],
+          resource_domains: ["https://cdn.justcall.io"],
+          redirect_domains: ["https://app.justcall.io"],
+        },
+        "openai/widgetDomain": "https://mcp.justcall.host",
+        "openai/widgetDescription": "Shows the list of calls",
       },
     },
     (
@@ -87,6 +94,13 @@ export const registerCallTools = (server: McpServer) => {
       text: "Calls Get",
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-get.html",
+        "openai/widgetCSP": {
+          connect_domains: ["https://app.justcall.io"],
+          resource_domains: ["https://cdn.justcall.io"],
+          redirect_domains: ["https://app.justcall.io"],
+        },
+        "openai/widgetDomain": "https://mcp.justcall.host",
+        "openai/widgetDescription": "Shows the details of a call",
       },
     },
     (


### PR DESCRIPTION
## Summary

This PR fixes Content Security Policy (CSP) errors that were preventing JustCall widgets from loading properly in the OpenAI Apps SDK. The fix adds proper CSP configuration and widget metadata to the call tools.

## Changes

- **Added CSP configuration** to `list_calls` and `get_call` tools:
  - `connect_domains`: Allows connections to `https://app.justcall.io`
  - `resource_domains`: Allows loading resources from `https://cdn.justcall.io`
  - `redirect_domains`: Allows redirects to `https://app.justcall.io`
  
- **Added widget metadata**:
  - `widgetDomain`: Set to `https://mcp.justcall.host`
  - `widgetDescription`: Added descriptive text for both widgets

## Technical Details

The CSP configuration is added via the `openai/widgetCSP` metadata field in the tool definitions. This ensures that OpenAI Apps SDK can properly load and display JustCall widgets without CSP violations.

## Version

- Bumped version from `1.2.0` to `1.2.1`

## Related

- Fixes CSP errors when using JustCall widgets in OpenAI Apps SDK
- Builds on the OpenAI Apps SDK support added in v1.2.0

