### PR TITLE
IN-8258: Added changes for appointments id from number to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 1.2.2
+
+### Patch Changes
+
+- IN-8258 | Added fixes for changes in Get Appointment Id from Number to String
+
 ## 1.2.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/src/dto/justcall/appointments.ts
+++ b/src/dto/justcall/appointments.ts
@@ -20,5 +20,5 @@ export interface CreateAppointmentDto extends BaseJustCallDto {
 }
 
 export interface GetAppointmentDto extends BaseJustCallDto {
-  id: number;
+  id: string;
 }

--- a/src/schema/justcall/appointments.ts
+++ b/src/schema/justcall/appointments.ts
@@ -46,5 +46,9 @@ export const CreateAppointmentSchema = {
 };
 
 export const GetAppointmentSchema = {
-  id: z.number().describe("Unique identifier of the appointment"),
+  id: z
+    .string()
+    .describe(
+      "Unique identifier of the appointment (use the entire id string, e.g. 698d856d1aXXefXXXc47194c)",
+    ),
 };


### PR DESCRIPTION
## Summary

Added fixes for `get_appointments` tool to  fetch details of appointments created in JustCall.
## Changes

- **DTO**: Fixed `GetAppointmentDto` interface in `src/dto/justcall/appointments.ts`
- **Schema**: Fixed `GetAppointmentSchema` with Zod validation in `src/schema/justcall/appointments.ts`

## Features

- Added fixes for Get appointments tool

## Testing

✅ Create Appointments Tested
✅  Get available Slots tested
✅  Using Id created post creation, get appointment tested in follow up conversation
