### PR TITLE
chore: Handle destructive hints returned by the MCP server correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @justcall/mcp-server
 
+## 1.2.3
+
+### Patch Changes
+
+- Fix destructive hints returned by the MCP server
+
 ## 1.2.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justcall/mcp-server",
   "description": "JustCall MCP Server",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "src/index.ts",

--- a/src/tools/justcall/ai.ts
+++ b/src/tools/justcall/ai.ts
@@ -19,6 +19,7 @@ export const registerAiTools = (server: McpServer) => {
     ListCallsAiDataSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -36,6 +37,7 @@ export const registerAiTools = (server: McpServer) => {
     GetCallAiDataSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -53,6 +55,7 @@ export const registerAiTools = (server: McpServer) => {
     ListMeetingsAiDataSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -70,6 +73,7 @@ export const registerAiTools = (server: McpServer) => {
     GetMeetingAiDataSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/analytics.ts
+++ b/src/tools/justcall/analytics.ts
@@ -18,6 +18,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
     GetAgentAnalyticsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -36,6 +37,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
     GetAccountAnalyticsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -54,6 +56,7 @@ export const registerAnalyticsTools = (server: McpServer) => {
     GetNumberAnalyticsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/appointments.ts
+++ b/src/tools/justcall/appointments.ts
@@ -18,6 +18,7 @@ export const registerAppointmentTools = (server: McpServer) => {
     ListAppointmentSlotsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -33,6 +34,9 @@ export const registerAppointmentTools = (server: McpServer) => {
     "create_appointment",
     "Schedule a new appointment on a specific JustCall calendar",
     CreateAppointmentSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createAppointment({
@@ -49,6 +53,7 @@ export const registerAppointmentTools = (server: McpServer) => {
     GetAppointmentSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/call.ts
+++ b/src/tools/justcall/call.ts
@@ -30,6 +30,7 @@ export const registerCallTools = (server: McpServer) => {
       inputSchema: ListCallsSchema,
       annotations: {
         readOnlyHint: true,
+        destructiveHint: false,
       },
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-list.html",
@@ -53,9 +54,7 @@ export const registerCallTools = (server: McpServer) => {
     "calls_list_widget",
     "ui://widget/calls-list.html",
     {
-      uri: "ui://widget/calls-list.html",
       mimeType: "text/html+skybridge",
-      text: "Calls list",
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-list.html",
         "openai/widgetCSP": {
@@ -89,9 +88,7 @@ export const registerCallTools = (server: McpServer) => {
     "call_get_widget",
     "ui://widget/calls-get.html",
     {
-      uri: "ui://widget/calls-get.html",
       mimeType: "text/html+skybridge",
-      text: "Calls Get",
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-get.html",
         "openai/widgetCSP": {
@@ -131,6 +128,7 @@ export const registerCallTools = (server: McpServer) => {
       inputSchema: GetCallSchema,
       annotations: {
         readOnlyHint: true,
+        destructiveHint: false,
       },
       _meta: {
         "openai/outputTemplate": "ui://widget/calls-get.html",
@@ -155,6 +153,9 @@ export const registerCallTools = (server: McpServer) => {
     "update_call",
     "Update/modify details of an existing call record identified by Call ID",
     UpdateCallSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.updateCall({
@@ -172,6 +173,7 @@ export const registerCallTools = (server: McpServer) => {
     GetCallJourneySchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -190,6 +192,7 @@ export const registerCallTools = (server: McpServer) => {
     GetVoiceAgentSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/contacts.ts
+++ b/src/tools/justcall/contacts.ts
@@ -22,6 +22,7 @@ export const registerContactTools = (server: McpServer) => {
     ListContactsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -40,6 +41,7 @@ export const registerContactTools = (server: McpServer) => {
     GetContactSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -55,6 +57,9 @@ export const registerContactTools = (server: McpServer) => {
     "create_contact",
     "Create a new contact in the JustCall account",
     CreateContactSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createContact({
@@ -70,6 +75,9 @@ export const registerContactTools = (server: McpServer) => {
     "update_contact",
     "Update/modify details of an existing contact in the JustCall account",
     UpdateContactSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.updateContact({
@@ -84,6 +92,9 @@ export const registerContactTools = (server: McpServer) => {
     "update_contact_status",
     "Add or remove a contact from DND/DNM/Blacklist lists in the JustCall account",
     UpdateContactStatusSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.updateContactStatus({
@@ -98,6 +109,9 @@ export const registerContactTools = (server: McpServer) => {
     "add_contacts_blacklist",
     "Add one or more contacts to the JustCall account's global blacklist in bulk",
     AddContactsBlacklistSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.addContactsBlacklist({
@@ -114,6 +128,7 @@ export const registerContactTools = (server: McpServer) => {
     ListBlacklistContactsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/numbers.ts
+++ b/src/tools/justcall/numbers.ts
@@ -14,6 +14,7 @@ export const registerNumberTools = (server: McpServer) => {
     ListNumbersSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -32,6 +33,7 @@ export const registerNumberTools = (server: McpServer) => {
     GetNumberSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/sms.ts
+++ b/src/tools/justcall/sms.ts
@@ -24,6 +24,9 @@ export const registerSmsTools = (server: McpServer) => {
     "send_sms_mms",
     "Send a new sms or text message or mms to a contact number",
     SendSmsSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.sendSms({
@@ -41,6 +44,7 @@ export const registerSmsTools = (server: McpServer) => {
     ListSmsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -59,6 +63,7 @@ export const registerSmsTools = (server: McpServer) => {
     GetSmsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -77,6 +82,7 @@ export const registerSmsTools = (server: McpServer) => {
     CheckSmsReplySchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -95,6 +101,7 @@ export const registerSmsTools = (server: McpServer) => {
     ListSmsTagsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -113,6 +120,7 @@ export const registerSmsTools = (server: McpServer) => {
     GetSmsTagSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -129,6 +137,9 @@ export const registerSmsTools = (server: McpServer) => {
     "create_sms_tag",
     "Create a new sms tag in the JustCall account for tagging conversations",
     CreateSmsTagSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createSmsTag({
@@ -144,6 +155,9 @@ export const registerSmsTools = (server: McpServer) => {
     "delete_sms_tag",
     "Delete a specific sms tag by ID",
     DeleteSmsTagSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.deleteSmsTag({
@@ -161,6 +175,7 @@ export const registerSmsTools = (server: McpServer) => {
     ListSmsThreadsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -178,6 +193,7 @@ export const registerSmsTools = (server: McpServer) => {
     GetSmsThreadSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -193,6 +209,9 @@ export const registerSmsTools = (server: McpServer) => {
     "add_sms_thread_thread",
     "Add tag to a sms thread/conversation identified by thread ID or combination of contact number and JustCall number",
     AddTagToThreadSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.addTagToThread({

--- a/src/tools/justcall/userGroups.ts
+++ b/src/tools/justcall/userGroups.ts
@@ -17,6 +17,7 @@ export const registerUserGroupTools = (server: McpServer) => {
     ListUserGroupsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -34,6 +35,7 @@ export const registerUserGroupTools = (server: McpServer) => {
     GetUserGroupSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/justcall/users.ts
+++ b/src/tools/justcall/users.ts
@@ -18,6 +18,7 @@ export const registerUserTools = (server: McpServer) => {
     ListUsersSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -36,6 +37,7 @@ export const registerUserTools = (server: McpServer) => {
     GetUserSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -52,6 +54,9 @@ export const registerUserTools = (server: McpServer) => {
     "update_user_availability",
     "Update a user's availability status in JustCall to available or unavailable for calls",
     UpdateUserAvailabilitySchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.updateUserAvailability({

--- a/src/tools/justcall/voiceAgent.ts
+++ b/src/tools/justcall/voiceAgent.ts
@@ -17,6 +17,7 @@ export const registerVoiceAgentTools = (server: McpServer) => {
     ListVoiceAgentsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -33,6 +34,9 @@ export const registerVoiceAgentTools = (server: McpServer) => {
     "create_voice_agent_call",
     "Initiate an outbound call from a configured AI voice agent to a contact number",
     InitiateVoiceAgentCallSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.initiateVoiceAgentCall({

--- a/src/tools/justcall/webhooks.ts
+++ b/src/tools/justcall/webhooks.ts
@@ -14,6 +14,7 @@ export const registerWebhookTools = (server: McpServer) => {
     ListWebhooksSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -30,6 +31,9 @@ export const registerWebhookTools = (server: McpServer) => {
     "create_webhook",
     "Create a new webhook endpoint to receive real-time notifications",
     CreateWebhookSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.createWebhook({

--- a/src/tools/justcall/whatsapp.ts
+++ b/src/tools/justcall/whatsapp.ts
@@ -20,6 +20,7 @@ export const registerWhatsAppTools = (server: McpServer) => {
     ListWhatsAppMessagesSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -37,6 +38,7 @@ export const registerWhatsAppTools = (server: McpServer) => {
     GetWhatsAppMessageSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -52,6 +54,9 @@ export const registerWhatsAppTools = (server: McpServer) => {
     "send_whatsapp_message",
     "Send a new whatsapp message to a contact number",
     SendWhatsAppMessageSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return justcallAPIservice.sendWhatsAppMessage({
@@ -68,6 +73,7 @@ export const registerWhatsAppTools = (server: McpServer) => {
     ListWhatsAppTemplatesSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -85,6 +91,7 @@ export const registerWhatsAppTools = (server: McpServer) => {
     CheckWhatsAppReplySchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/salesdialer/analytics.ts
+++ b/src/tools/salesdialer/analytics.ts
@@ -14,6 +14,7 @@ export const registerSalesDialerAnalyticsTools = (server: McpServer) => {
     GetSalesDialerAnalyticsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/salesdialer/calls.ts
+++ b/src/tools/salesdialer/calls.ts
@@ -17,6 +17,7 @@ export const registerSalesDialerCallTools = (server: McpServer) => {
     ListSalesDialerCallsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -34,6 +35,7 @@ export const registerSalesDialerCallTools = (server: McpServer) => {
     GetSalesDialerCallSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);

--- a/src/tools/salesdialer/campaigns.ts
+++ b/src/tools/salesdialer/campaigns.ts
@@ -21,6 +21,7 @@ export const registerCampaignTools = (server: McpServer) => {
     ListCampaignsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -39,6 +40,7 @@ export const registerCampaignTools = (server: McpServer) => {
     GetCampaignSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -55,6 +57,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "create_salesdialer_campaign",
     "Create a new Sales Dialer campaign in the JustCall account",
     CreateCampaignSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.createCampaign({
@@ -70,6 +75,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "update_salesdialer_campaign",
     "Update/modify details of an existing Sales Dialer campaign in the JustCall account",
     UpdateCampaignSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.updateCampaign({
@@ -87,6 +95,7 @@ export const registerCampaignTools = (server: McpServer) => {
     ListCampaignContactsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -102,6 +111,9 @@ export const registerCampaignTools = (server: McpServer) => {
     "add_salesdialer_campaign_contact",
     "Add contact to a specific Sales Dialer campaign identified by Campaign ID",
     AddContactToCampaignSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.addContactToCampaign({

--- a/src/tools/salesdialer/contacts.ts
+++ b/src/tools/salesdialer/contacts.ts
@@ -23,6 +23,7 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     ListSalesDialerContactsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -40,6 +41,7 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     GetSalesDialerContactSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -55,6 +57,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "create_salesdialer_contact",
     "Create a new contact in Sales Dialer",
     CreateSalesDialerContactSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.createSalesDialerContact({
@@ -69,6 +74,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "update_salesdialer_contact",
     "Update/modify details of an existing contact in Sales Dialer identified by ID",
     UpdateSalesDialerContactSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.updateSalesDialerContact({
@@ -83,6 +91,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "import_salesdialer_contacts",
     "Import multiple contacts into Sales Dialer or a campaign in bulk",
     ImportSalesDialerContactsSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.importSalesDialerContacts({
@@ -99,6 +110,7 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     ImportSalesDialerContactsStatusSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
@@ -114,6 +126,9 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     "add_salesdialer_contacts_dnca",
     'Add one or more contacts to the Sales Dialer\'s "Do Not Call Again" list in bulk',
     AddSalesDialerContactsDncaSchema,
+    {
+      destructiveHint: true,
+    },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);
       return salesdialerAPIservice.addSalesDialerContactsDnca({
@@ -130,6 +145,7 @@ export const registerSalesDialerContactTools = (server: McpServer) => {
     ListSalesDialerCustomFieldsSchema,
     {
       readOnlyHint: true,
+      destructiveHint: false,
     },
     createToolHandler(async (params, context) => {
       const authToken = getAuthToken(context);


### PR DESCRIPTION
- Update tool handlers to include destructiveHint metadata in MCP server tool registration.
- If create/update/delete/communication operations are performed, the destructiveHint should be set to true.
- If read operations are performed, the destructiveHint should be set to false.